### PR TITLE
Prev next contactw

### DIFF
--- a/buttons.ts
+++ b/buttons.ts
@@ -35,7 +35,7 @@ const whiteSqBtn = defineStyle({
   paddingX: "0",
   fontSize: { base: "16px", lg: "18px" },
   h: { base: "44px", lg: "54px" },
-  w: { base: "160px", md: "200px", xl: "250px" },
+  w: { base: "120px", md: "150px" },
   // maxW: { base: '284px', lg: '359px ' },
   fontWeight: { base: "500", lg: "600", xl: "700" },
   lineHeight: "1",

--- a/src/app/contacts/[slug]/components/PrevNext.tsx
+++ b/src/app/contacts/[slug]/components/PrevNext.tsx
@@ -1,0 +1,21 @@
+"use client";
+import SectionContainer from "@/app/components/SectionContainer";
+import { Button, Flex, Icon, Link } from "@chakra-ui/react";
+import React from "react";
+import { ContactProps } from "@/data/contacts";
+
+export default function PrevNext({ contact }: { contact: ContactProps }) {
+  console.log(contact.id <= 1);
+  return (
+    <SectionContainer>
+      <Flex w={"100"} align={"center"} justify={"center"}>
+        <Link>
+          <Button me={"2rem"} variant={"linkBtn"} isDisabled={contact.id <= 1}>
+            Previous
+          </Button>
+        </Link>
+        <Button variant={"linkBtn"}>Next</Button>
+      </Flex>
+    </SectionContainer>
+  );
+}

--- a/src/app/contacts/[slug]/components/PrevNext.tsx
+++ b/src/app/contacts/[slug]/components/PrevNext.tsx
@@ -4,17 +4,26 @@ import { Button, Flex, Icon, Link } from "@chakra-ui/react";
 import React from "react";
 import { ContactProps } from "@/data/contacts";
 
-export default function PrevNext({ contact }: { contact: ContactProps }) {
-  console.log(contact.id <= 1);
+export default function PrevNext({
+  contact,
+  length,
+}: {
+  contact: ContactProps;
+  length: number;
+}) {
   return (
     <SectionContainer>
       <Flex w={"100"} align={"center"} justify={"center"}>
-        <Link>
+        <Link href={`/contacts/${contact.id - 1}`}>
           <Button me={"2rem"} variant={"linkBtn"} isDisabled={contact.id <= 1}>
             Previous
           </Button>
         </Link>
-        <Button variant={"linkBtn"}>Next</Button>
+        <Link href={`/contacts/${contact.id + 1}`}>
+          <Button variant={"linkBtn"} isDisabled={contact.id === length}>
+            Next
+          </Button>
+        </Link>
       </Flex>
     </SectionContainer>
   );

--- a/src/app/contacts/[slug]/page.tsx
+++ b/src/app/contacts/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import SectionContainer from "../../components/SectionContainer";
-import { fetchContact } from "@/app/utils";
+import { fetchContact, fetchContacts } from "@/app/utils";
 import ContactInfo from "./components/ContactInfo";
 import { Metadata } from "next";
 import PrevNext from "./components/PrevNext";
@@ -24,12 +24,13 @@ export async function generateMetadata({
 }
 
 export default async function Contact({ params: { slug } }: Params) {
-  const contact = await fetchContact(slug);
+  const contacts = await fetchContacts();
+  const contact = contacts.find((contact) => contact.id === Number(slug))!;
 
   return (
     <SectionContainer>
       <ContactInfo contact={contact} />
-      <PrevNext contact={contact} />
+      <PrevNext contact={contact} length={contacts.length} />
     </SectionContainer>
   );
 }

--- a/src/app/contacts/[slug]/page.tsx
+++ b/src/app/contacts/[slug]/page.tsx
@@ -3,6 +3,7 @@ import SectionContainer from "../../components/SectionContainer";
 import { fetchContact } from "@/app/utils";
 import ContactInfo from "./components/ContactInfo";
 import { Metadata } from "next";
+import PrevNext from "./components/PrevNext";
 
 type Params = {
   params: {
@@ -28,6 +29,7 @@ export default async function Contact({ params: { slug } }: Params) {
   return (
     <SectionContainer>
       <ContactInfo contact={contact} />
+      <PrevNext contact={contact} />
     </SectionContainer>
   );
 }


### PR DESCRIPTION
Butons to move to previous and next contacts
removed `fetchContact`. Needed the length of the contacts array to disable the next button at the last contact in the array. So used `contacts.find` to retrieve the correct contact